### PR TITLE
Correct link to avea_server branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # avea_server
 Wrapper around avea-node for exposing avea bulbs as HTTP API
 
-See https://github.com/Marmelatze/avea_bulb for the bulb access
+See https://github.com/Marmelatze/avea_bulb/tree/avea_server for the bulb access


### PR DESCRIPTION
The linked master branch vom avea_bulb does not work with avea_server, as mentioned here: https://github.com/Marmelatze/avea_bulb/issues/7

To avoid confusion I think this will help new users as long as the avea_server branch is not merged into master